### PR TITLE
Fix to compile with Visual C++ 2015

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/seanmiddleditch/libtelnet.svg?branch=master)](https://travis-ci.org/seanmiddleditch/libtelnet)
+
 =====================================================================
   libtelnet - TELNET protocol handling library
 =====================================================================

--- a/libtelnet.h
+++ b/libtelnet.h
@@ -59,6 +59,11 @@ extern "C" {
 # define TELNET_GNU_SENTINEL /*!< internal helper */
 #endif
 
+/* Disable environ macro in Visual C++ */
+#ifdef _MSC_VER
+# undef environ
+#endif
+
 /*! Telnet state tracker object type. */
 typedef struct telnet_t telnet_t;
 

--- a/libtelnet.h
+++ b/libtelnet.h
@@ -59,10 +59,8 @@ extern "C" {
 # define TELNET_GNU_SENTINEL /*!< internal helper */
 #endif
 
-/* Disable environ macro in Visual C++ */
-#ifdef _MSC_VER
-# undef environ
-#endif
+/* Disable environ macro for Visual C++ 2015. */
+#undef environ
 
 /*! Telnet state tracker object type. */
 typedef struct telnet_t telnet_t;

--- a/msvc2010/telnet-proxy.vcxproj
+++ b/msvc2010/telnet-proxy.vcxproj
@@ -18,12 +18,12 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/msvc2010/telnet-proxy.vcxproj
+++ b/msvc2010/telnet-proxy.vcxproj
@@ -18,12 +18,12 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <CharacterSet>MultiByte</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/util/telnet-chatd.c
+++ b/util/telnet-chatd.c
@@ -34,10 +34,7 @@
 #	define poll WSAPoll
 #	define close closesocket
 #	define strdup _strdup
-
-#if !defined(_MSC_VER) || _MSC_VER < 1600 // VC 9 and prior do not define this macro
 #	define ECONNRESET WSAECONNRESET
-#endif
 #endif
 
 #include <errno.h>

--- a/util/telnet-chatd.c
+++ b/util/telnet-chatd.c
@@ -27,11 +27,17 @@
 #	include <winsock2.h>
 #	include <ws2tcpip.h>
 
+#if !defined(_MSC_VER) || _MSC_VER < 1800
 #	define snprintf _snprintf
+#endif
+
 #	define poll WSAPoll
 #	define close closesocket
 #	define strdup _strdup
+
+#if !defined(_MSC_VER) || _MSC_VER < 1600 // VC 9 and prior do not define this macro
 #	define ECONNRESET WSAECONNRESET
+#endif
 #endif
 
 #include <errno.h>

--- a/util/telnet-chatd.c
+++ b/util/telnet-chatd.c
@@ -27,7 +27,7 @@
 #	include <winsock2.h>
 #	include <ws2tcpip.h>
 
-#if !defined(_MSC_VER) || _MSC_VER < 1800
+#ifndef _UCRT
 #	define snprintf _snprintf
 #endif
 

--- a/util/telnet-proxy.c
+++ b/util/telnet-proxy.c
@@ -27,7 +27,7 @@
 #	include <winsock2.h>
 #	include <ws2tcpip.h>
 
-#if !defined(_MSC_VER) || _MSC_VER < 1900
+#ifndef _UCRT
 #	define snprintf _snprintf
 #endif
 

--- a/util/telnet-proxy.c
+++ b/util/telnet-proxy.c
@@ -27,7 +27,10 @@
 #	include <winsock2.h>
 #	include <ws2tcpip.h>
 
+#if !defined(_MSC_VER) || _MSC_VER < 1900
 #	define snprintf _snprintf
+#endif
+
 #	define poll WSAPoll
 #	define close closesocket
 

--- a/util/telnet-proxy.c
+++ b/util/telnet-proxy.c
@@ -33,6 +33,8 @@
 
 #	define poll WSAPoll
 #	define close closesocket
+#	undef gai_strerror
+#	define gai_strerror gai_strerrorA
 
 #if !defined(_MSC_VER) || _MSC_VER < 1600 // VC 9 and prior do not define this macro
 #	define ECONNRESET WSAECONNRESET

--- a/util/telnet-proxy.c
+++ b/util/telnet-proxy.c
@@ -35,10 +35,7 @@
 #	define close closesocket
 #	undef gai_strerror
 #	define gai_strerror gai_strerrorA
-
-#if !defined(_MSC_VER) || _MSC_VER < 1600 // VC 9 and prior do not define this macro
 #	define ECONNRESET WSAECONNRESET
-#endif
 #endif
 
 #include <errno.h>


### PR DESCRIPTION
Some fixes for Visual C++ 2015.

- Add `#undef environ`. Because `environ` is defined `(*__p__environ())` in `<stdlib.h>`.
- Remove `snprintf` macro. Visual C++ 2015 has `snprintf`.
- Remove `ECONNRESET` macro. This is copy from `libtelnet-proxy.c` to `libtelnet-chatd.c`.