### PR TITLE
Fix for buffer containing \0 characters

### DIFF
--- a/util/telnet-client.c
+++ b/util/telnet-client.c
@@ -100,7 +100,9 @@ static void _event_handler(telnet_t *telnet, telnet_event_t *ev,
 	switch (ev->type) {
 	/* data received */
 	case TELNET_EV_DATA:
-		printf("%.*s", (int)ev->data.size, ev->data.buffer);
+		if (ev->data.size && fwrite(ev->data.buffer, 1, ev->data.size, stdout) != ev->data.size) {
+              		fprintf(stderr, "ERROR: Could not write complete buffer to stdout");
+		}
 		fflush(stdout);
 		break;
 	/* data must be sent */


### PR DESCRIPTION
Rebased to develop branch. First I rebased from master to develop, but then I noticed the develop branch is 4 commits behind master. So then I just reset both master/develop and added the changes again. Not sure if there was a better way to do this ;)

Orignal pull request:
-----------------------
As the server could return a large piece of data (e.g. a message-of-the-day) containing multiple \0 terminated strings, printf("%.*s", ...) is not sufficient for writing to stdout as that will stop on the first \0 character.
