### PR TITLE
fix error: expected specifier-qualifier-list before ‘size_t’

### DIFF
--- a/libtelnet.h
+++ b/libtelnet.h
@@ -44,7 +44,7 @@
 
 /* standard C headers necessary for the libtelnet API */
 #include <stdarg.h>
-#include <sys/types.h>
+#include <stddef.h>
 
 /* C++ support */
 #if defined(__cplusplus)

--- a/libtelnet.h
+++ b/libtelnet.h
@@ -44,6 +44,7 @@
 
 /* standard C headers necessary for the libtelnet API */
 #include <stdarg.h>
+#include <sys/types.h>
 
 /* C++ support */
 #if defined(__cplusplus)


### PR DESCRIPTION
libtelnet.h:246: error: expected specifier-qualifier-list before ‘size_t’


centos 6.9
gcc version 4.4.7 20120313 (Red Hat 4.4.7-18) (GCC)