### PR TITLE
Add EOL translation when sending and receiving text not in BINARY mode

### DIFF
--- a/README
+++ b/README
@@ -146,13 +146,13 @@ IIb. Receiving Data
    process output.
 
  size_t telnet_translate_eol(telnet_t *telnet,
-     char *buffer, size_t size, int *split);
+     char *buffer, size_t size, int *eol_was_split);
    Scans a buffer received in a TELNET_EV_DATA event to translate the
    TELNET NVT CR NUL and CR LF sequences specified in RFC854 to C
    carriage return (\r) and C newline (\n), respectively.  Sequences
-   split across a buffer boundary are handled using the split flag
-   that should be initialized to 0.  The return code is the possibly
-   shorter length of the text after translation.
+   split across a buffer boundary are handled using the eol_was_split
+   flag that should be initialized to 0 before the first call.  The
+   possibly shorter length of the text after translation is returned.
 
 IIc. Sending Data
 

--- a/README
+++ b/README
@@ -145,6 +145,15 @@ IIb. Receiving Data
    triggered for any regular data such as user input or server
    process output.
 
+ size_t telnet_translate_eol(telnet_t *telnet,
+     char *buffer, size_t size, int *split);
+   Scans a buffer received in a TELNET_EV_DATA event to translate the
+   TELNET NVT CR NUL and CR LF sequences specified in RFC854 to C
+   carriage return (\r) and C newline (\n), respectively.  Sequences
+   split across a buffer boundary are handled using the split flag
+   that should be initialized to 0.  The return code is the possibly
+   shorter length of the text after translation.
+
 IIc. Sending Data
 
  All of the output functions will invoke the TELNET_EV_SEND event.
@@ -173,6 +182,12 @@ IIc. Sending Data
  void telnet_send(telnet_t *telnet, const char *buffer, size_t size);
    Sends raw data, which would be either the process output from a
    server or the user input from a client.
+
+ void telnet_send_text(telnet_t *telnet, const char *buffer,
+     size_t size);
+   Sends text characters with translation of C newlines (\n) into
+   CR LF and C carriage returns (\r) into CR NUL, as required by
+   RFC854, unless transmission in BINARY mode has been negotiated.
 
    For sending regular text is may be more convenient to use
    telnet_printf().

--- a/README
+++ b/README
@@ -189,7 +189,7 @@ IIc. Sending Data
    CR LF and C carriage returns (\r) into CR NUL, as required by
    RFC854, unless transmission in BINARY mode has been negotiated.
 
-   For sending regular text is may be more convenient to use
+   For sending regular text it may be more convenient to use
    telnet_printf().
  
  void telnet_begin_sb(telnet_t *telnet, unsigned char telopt);
@@ -228,14 +228,14 @@ IIc. Sending Data
    detect the COMPRESS2 marker and enable zlib compression.
 
  int telnet_printf(telnet_t *telnet, const char *fmt, ...);
-  This functions very similarly to fprintf, except that output is
-  sent through libtelnet for processing.  IAC bytes are properly
-  escaped, C newlines (\n) are translated into CR LF, and C carriage
-  returns (\r) are translated into CR NUL, all as required by
-  RFC854.  The return code is the length of the formatted text.
+   This functions very similarly to fprintf, except that output is
+   sent through libtelnet for processing.  IAC bytes are properly
+   escaped, C newlines (\n) are translated into CR LF, and C carriage
+   returns (\r) are translated into CR NUL, all as required by
+   RFC854.  The return code is the length of the formatted text.
 
-  NOTE: due to an internal implementation detail, the maximum
-  lenth of the formatted text is 4096 characters.
+   NOTE: due to an internal implementation detail, the maximum
+   length of the formatted text is 4096 characters.
 
 IId. Event Handling
 

--- a/libtelnet.h
+++ b/libtelnet.h
@@ -371,7 +371,7 @@ struct telnet_t;
  * \param eh        Event handler function called for every event.
  * \param flags     0 or TELNET_FLAG_PROXY.
  * \param user_data Optional data pointer that will be passsed to eh.
- * \return Telent state tracker object.
+ * \return Telnet state tracker object.
  */
 extern telnet_t* telnet_init(const telnet_telopt_t *telopts,
 		telnet_event_handler_t eh, unsigned char flags, void *user_data);

--- a/libtelnet.h
+++ b/libtelnet.h
@@ -435,6 +435,30 @@ extern void telnet_send(telnet_t *telnet,
 		const char *buffer, size_t size);
 
 /*!
+ * Send non-command text (escapes IAC bytes and translates
+ * \\r -> CR-NUL and \\n -> CR-LF unless in BINARY mode.
+ *
+ * \param telnet Telnet state tracker object.
+ * \param buffer Buffer of bytes to send.
+ * \param size   Number of bytes to send.
+ */
+extern void telnet_send_text(telnet_t *telnet,
+		const char *buffer, size_t size);
+
+/*!
+ * Translate NVT EOL byte sequences into local characters
+ * (CR-NUL -> \\r and CR-LF -> \\n) unless in BINARY mode.
+ *
+ * \param telnet Telnet state tracker object.
+ * \param buffer Buffer of bytes to translate.
+ * \param size   Number of bytes to translate.
+ * \param split  1 if in the middle of EOL byte pair at start/end.
+ * \return Number of bytes after translation.
+ */
+extern size_t telnet_translate_eol(telnet_t *telnet,
+		char *buffer, size_t size, int *split);
+
+/*!
  * \brief Begin a sub-negotiation command.
  *
  * Sends IAC SB followed by the telopt code.  All following data sent


### PR DESCRIPTION
As you offered, here is a pull request to add functions to perform the EOL translation.

I made the assumption here that it was OK to add some internal flags in the state tracker flags byte to hold the current state of BINARY transmission and reception modes and to set those flags in _set_rfc1143.

I believe I have followed the style and documentation conventions correctly.