### PR TITLE
Alternative pull request with EOL translation in process()

### DIFF
--- a/README
+++ b/README
@@ -146,13 +146,13 @@ IIb. Receiving Data
    process output.
 
  size_t telnet_translate_eol(telnet_t *telnet,
-     char *buffer, size_t size, int *split);
+     char *buffer, size_t size, int *eol_was_split);
    Scans a buffer received in a TELNET_EV_DATA event to translate the
    TELNET NVT CR NUL and CR LF sequences specified in RFC854 to C
    carriage return (\r) and C newline (\n), respectively.  Sequences
-   split across a buffer boundary are handled using the split flag
-   that should be initialized to 0.  The return code is the possibly
-   shorter length of the text after translation.
+   split across a buffer boundary are handled using the eol_was_split
+   flag that should be initialized to 0 before the first call.  The
+   possibly shorter length of the text after translation is returned.
 
 IIc. Sending Data
 

--- a/README
+++ b/README
@@ -145,6 +145,15 @@ IIb. Receiving Data
    triggered for any regular data such as user input or server
    process output.
 
+ size_t telnet_translate_eol(telnet_t *telnet,
+     char *buffer, size_t size, int *split);
+   Scans a buffer received in a TELNET_EV_DATA event to translate the
+   TELNET NVT CR NUL and CR LF sequences specified in RFC854 to C
+   carriage return (\r) and C newline (\n), respectively.  Sequences
+   split across a buffer boundary are handled using the split flag
+   that should be initialized to 0.  The return code is the possibly
+   shorter length of the text after translation.
+
 IIc. Sending Data
 
  All of the output functions will invoke the TELNET_EV_SEND event.
@@ -173,6 +182,12 @@ IIc. Sending Data
  void telnet_send(telnet_t *telnet, const char *buffer, size_t size);
    Sends raw data, which would be either the process output from a
    server or the user input from a client.
+
+ void telnet_send_text(telnet_t *telnet, const char *buffer,
+     size_t size);
+   Sends text characters with translation of C newlines (\n) into
+   CR LF and C carriage returns (\r) into CR NUL, as required by
+   RFC854, unless transmission in BINARY mode has been negotiated.
 
    For sending regular text is may be more convenient to use
    telnet_printf().

--- a/README
+++ b/README
@@ -123,6 +123,11 @@ IIa. Initialization
       Operate in proxy mode.  This disables the RFC1143 support and
       enables automatic detection of COMPRESS2 streams.
 
+    TELNET_FLAG_NVT_EOL
+      Receive data with translation of the TELNET NVT CR NUL and CR LF
+      sequences specified in RFC854 to C carriage return (\r) and C
+      newline (\n), respectively.
+
    If telnet_init() fails to allocate the required memory, the
    returned pointer will be zero.
  
@@ -144,15 +149,6 @@ IIb. Receiving Data
    interest for data receiving is the TELNET_EV_DATA event, which is
    triggered for any regular data such as user input or server
    process output.
-
- size_t telnet_translate_eol(telnet_t *telnet,
-     char *buffer, size_t size, int *eol_was_split);
-   Scans a buffer received in a TELNET_EV_DATA event to translate the
-   TELNET NVT CR NUL and CR LF sequences specified in RFC854 to C
-   carriage return (\r) and C newline (\n), respectively.  Sequences
-   split across a buffer boundary are handled using the eol_was_split
-   flag that should be initialized to 0 before the first call.  The
-   possibly shorter length of the text after translation is returned.
 
 IIc. Sending Data
 

--- a/README
+++ b/README
@@ -189,7 +189,7 @@ IIc. Sending Data
    CR LF and C carriage returns (\r) into CR NUL, as required by
    RFC854, unless transmission in BINARY mode has been negotiated.
 
-   For sending regular text is may be more convenient to use
+   For sending regular text it may be more convenient to use
    telnet_printf().
  
  void telnet_begin_sb(telnet_t *telnet, unsigned char telopt);
@@ -228,14 +228,14 @@ IIc. Sending Data
    detect the COMPRESS2 marker and enable zlib compression.
 
  int telnet_printf(telnet_t *telnet, const char *fmt, ...);
-  This functions very similarly to fprintf, except that output is
-  sent through libtelnet for processing.  IAC bytes are properly
-  escaped, C newlines (\n) are translated into CR LF, and C carriage
-  returns (\r) are translated into CR NUL, all as required by
-  RFC854.  The return code is the length of the formatted text.
+   This functions very similarly to fprintf, except that output is
+   sent through libtelnet for processing.  IAC bytes are properly
+   escaped, C newlines (\n) are translated into CR LF, and C carriage
+   returns (\r) are translated into CR NUL, all as required by
+   RFC854.  The return code is the length of the formatted text.
 
-  NOTE: due to an internal implementation detail, the maximum
-  lenth of the formatted text is 4096 characters.
+   NOTE: due to an internal implementation detail, the maximum
+   length of the formatted text is 4096 characters.
 
 IId. Event Handling
 

--- a/libtelnet.c
+++ b/libtelnet.c
@@ -64,6 +64,7 @@
 /* telnet state codes */
 enum telnet_state_t {
 	TELNET_STATE_DATA = 0,
+	TELNET_STATE_EOL,
 	TELNET_STATE_IAC,
 	TELNET_STATE_WILL,
 	TELNET_STATE_WONT,
@@ -104,10 +105,6 @@ struct telnet_t {
 	/* length of RFC1143 queue */
 	unsigned char q_size;
 };
-
-/* Internal-only bits in option flags */
-#define TELNET_FLAG_TRANSMIT_BINARY (1<<1)
-#define TELNET_FLAG_RECEIVE_BINARY (1<<2)
 
 /* RFC1143 option negotiation state */
 typedef struct telnet_rfc1143_t {
@@ -978,7 +975,36 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
 					telnet->eh(telnet, &ev, telnet->ud);
 				}
 				telnet->state = TELNET_STATE_IAC;
+			} else if (byte == '\r' &&
+					   (telnet->flags & TELNET_FLAG_NVT_EOL) &&
+					   !(telnet->flags & TELNET_FLAG_RECEIVE_BINARY)) {
+				if (i != start) {
+					ev.type = TELNET_EV_DATA;
+					ev.data.buffer = buffer + start;
+					ev.data.size = i - start;
+					telnet->eh(telnet, &ev, telnet->ud);
+				}
+				telnet->state = TELNET_STATE_EOL;
 			}
+			break;
+
+		/* NVT EOL to be translated */
+		case TELNET_STATE_EOL:
+			if (byte != '\n') {
+				byte = '\r';
+				ev.type = TELNET_EV_DATA;
+				ev.data.buffer = (char*)&byte;
+				ev.data.size = 1;
+				telnet->eh(telnet, &ev, telnet->ud);
+				byte = buffer[i];
+			}
+			// any byte following '\r' other than '\n' or '\0' is invalid,
+			// so pass both \r and the byte
+			start = i;
+			if (byte == '\0')
+				++start;
+			/* state update */
+			telnet->state = TELNET_STATE_DATA;
 			break;
 
 		/* IAC command */
@@ -1135,49 +1161,6 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
 		ev.data.size = i - start;
 		telnet->eh(telnet, &ev, telnet->ud);
 	}
-}
-
-/* perform NVT end-of-line translation for received text */
-size_t telnet_translate_eol(telnet_t *telnet, char *buffer, size_t size,
-		int *eol_was_split) {
-	size_t i = 0, l = 0;
-	if (size == 0)
-		return size;
-	
-	/* no translation if in BINARY mode */
-	if (telnet->flags & TELNET_FLAG_RECEIVE_BINARY)
-		return size;
-
-	/* fix up translation if split across buffer boundary */
-	if (*eol_was_split) {
-		/* CR-NUL translates to \r which was skipped at end of previous */
-		/* buffer, while CR-LF translates to \n, so just leave it */
-		if (buffer[i] == '\0') {
-			buffer[i] = '\r';
-		}
-		++i;
-	}
-
-	for ( ; i < size-1; ++i, ++l) {
-		buffer[l] = buffer[i];
-		if (buffer[i] == '\r') {
-			if (buffer[i+1] == '\n') {
-				/* CR-LF translates to \n */
-				buffer[l] = '\n';
-				++i;
-			} else if (buffer[i+1] == '\0') {
-				/* CR-NUL translates to \r */
-				++i;
-			}
-		}
-	}
-	if (buffer[i] == '\r') {
-		--l;
-		*eol_was_split = 1;
-	} else {
-		*eol_was_split = 0;
-	}
-	return l + 1;
 }
 
 /* push a bytes into the state tracker */

--- a/libtelnet.h
+++ b/libtelnet.h
@@ -175,7 +175,11 @@ typedef struct telnet_telopt_t telnet_telopt_t;
 /*@{*/
 /*! Control behavior of telnet state tracker. */
 #define TELNET_FLAG_PROXY (1<<0)
+#define TELNET_FLAG_NVT_EOL (1<<1)
 
+/* Internal-only bits in option flags */
+#define TELNET_FLAG_TRANSMIT_BINARY (1<<5)
+#define TELNET_FLAG_RECEIVE_BINARY (1<<6)
 #define TELNET_PFLAG_DEFLATE (1<<7)
 /*@}*/
 
@@ -444,19 +448,6 @@ extern void telnet_send(telnet_t *telnet,
  */
 extern void telnet_send_text(telnet_t *telnet,
 		const char *buffer, size_t size);
-
-/*!
- * Translate NVT EOL byte sequences into local characters
- * (CR-NUL -> \\r and CR-LF -> \\n) unless in BINARY mode.
- *
- * \param telnet Telnet state tracker object.
- * \param buffer Buffer of bytes to translate.
- * \param size   Number of bytes to translate.
- * \param split  1 if in the middle of EOL byte pair at start/end.
- * \return Number of bytes after translation.
- */
-extern size_t telnet_translate_eol(telnet_t *telnet,
-		char *buffer, size_t size, int *split);
 
 /*!
  * \brief Begin a sub-negotiation command.

--- a/libtelnet.h
+++ b/libtelnet.h
@@ -371,7 +371,7 @@ struct telnet_t;
  * \param eh        Event handler function called for every event.
  * \param flags     0 or TELNET_FLAG_PROXY.
  * \param user_data Optional data pointer that will be passsed to eh.
- * \return Telent state tracker object.
+ * \return Telnet state tracker object.
  */
 extern telnet_t* telnet_init(const telnet_telopt_t *telopts,
 		telnet_event_handler_t eh, unsigned char flags, void *user_data);

--- a/libtelnet.h
+++ b/libtelnet.h
@@ -435,6 +435,30 @@ extern void telnet_send(telnet_t *telnet,
 		const char *buffer, size_t size);
 
 /*!
+ * Send non-command text (escapes IAC bytes and translates
+ * \\r -> CR-NUL and \\n -> CR-LF unless in BINARY mode.
+ *
+ * \param telnet Telnet state tracker object.
+ * \param buffer Buffer of bytes to send.
+ * \param size   Number of bytes to send.
+ */
+extern void telnet_send_text(telnet_t *telnet,
+		const char *buffer, size_t size);
+
+/*!
+ * Translate NVT EOL byte sequences into local characters
+ * (CR-NUL -> \\r and CR-LF -> \\n) unless in BINARY mode.
+ *
+ * \param telnet Telnet state tracker object.
+ * \param buffer Buffer of bytes to translate.
+ * \param size   Number of bytes to translate.
+ * \param split  1 if in the middle of EOL byte pair at start/end.
+ * \return Number of bytes after translation.
+ */
+extern size_t telnet_translate_eol(telnet_t *telnet,
+		char *buffer, size_t size, int *split);
+
+/*!
  * \brief Begin a sub-negotiation command.
  *
  * Sends IAC SB followed by the telopt code.  All following data sent


### PR DESCRIPTION
This is a cleaner solution in that the application does not have to call a separate telnet_translate_eol() function that makes another pass over the data.  It also avoids the eol_was_split boolean that must be kept by the application.  However, it does touch more of the previously existing code.