### PR TITLE
Cppcheck

### DIFF
--- a/libtelnet.c
+++ b/libtelnet.c
@@ -1482,6 +1482,7 @@ int telnet_vprintf(telnet_t *telnet, const char *fmt, va_list va) {
 		if (output == 0) {
 			_error(telnet, __LINE__, __func__, TELNET_ENOMEM, 0,
 					"malloc() failed: %s", strerror(errno));
+			va_end(va2);
 			return -1;
 		}
 		rs = vsnprintf(output, rs + 1, fmt, va2);
@@ -1551,6 +1552,7 @@ int telnet_raw_vprintf(telnet_t *telnet, const char *fmt, va_list va) {
 		if (output == 0) {
 			_error(telnet, __LINE__, __func__, TELNET_ENOMEM, 0,
 					"malloc() failed: %s", strerror(errno));
+			va_end(va2);
 			return -1;
 		}
 		rs = vsnprintf(output, rs + 1, fmt, va2);


### PR DESCRIPTION
Fix 'cppcheck' errors; add two va_end() calls on error exit.