### PR TITLE
Call event handler on WONT and DONT messages when in the Q_WANTYES state

### DIFF
--- a/libtelnet.c
+++ b/libtelnet.c
@@ -442,6 +442,7 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
 		case Q_WANTYES:
 		case Q_WANTYES_OP:
 			_set_rfc1143(telnet, telopt, Q_US(q), Q_NO);
+			NEGOTIATE_EVENT(telnet, TELNET_EV_WONT, telopt);
 			break;
 		}
 		break;
@@ -501,6 +502,7 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
 		case Q_WANTYES:
 		case Q_WANTYES_OP:
 			_set_rfc1143(telnet, telopt, Q_NO, Q_HIM(q));
+			NEGOTIATE_EVENT(telnet, TELNET_EV_DONT, telopt);
 			break;
 		}
 		break;


### PR DESCRIPTION
The idea here is that user code should get notified of a WONT response to a DO request, or a DONT response to a WILL request, so that it can do something like tell the client "your terminal doesn't support this feature, so you can't proceed further."

(It's possible I'm misunderstanding something and there's a better way to do this.)