### PR TITLE
<fix>(#55)

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1,12 +1,12 @@
 # only process documented members in our main header
 EXTRACT_ALL=no
-INPUT=@CMAKE_SOURCE_DIR@/libtelnet.h
+INPUT=@CMAKE_CURRENT_SOURCE_DIR@/../libtelnet.h
 
 # libtelnet is all C
 OPTIMIZE_OUTPUT_FOR_C=yes
 
 # put all output into the doc directory
-OUTPUT_DIRECTORY=@CMAKE_BINARY_DIR@/doc
+OUTPUT_DIRECTORY=@CMAKE_CURRENT_BINARY_DIR@
 
 # generate HTML and man pages only
 GENERATE_LATEX=no


### PR DESCRIPTION
When used as a submodule, the paths provided for documentation aren't
valid anymore.

Signed-off-by: Shea690901 <ginny690901@hotmail.de>