### PR TITLE
Telopt event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 .vscode/
+.idea/
+cmake-build-debug

--- a/README.md
+++ b/README.md
@@ -432,6 +432,20 @@ void my_event_handler(telnet_t *telnet, telnet_event_t *ev,
    Note that in PROXY mode libtelnet will do no processing of its
    own for you.
 
+* TELNET_EV_ENABLE_US / TELNET_EV_DISABLE_US / TELNET_EV_ENABLE_HIM / TELNET_EV_ENABLE_HIM
+
+   Triggered when the server alters the state of a telopt for the
+   application. ENABLE_US is triggered when the server sends WILL
+   and receives DO, DISABLE_US is triggered when the server
+   receives an arbitrary DONT after enabling an option.
+   
+   ENABLE_HIM is triggered when the server sends DO and receives
+   a WILL. DISABLE_HIM is triggered when a telopt is remotely
+   enabled but we sent a DONT.
+   
+   These are triggered in addition to TELNET_EV_WILL / WONT / DO
+   / DONT.
+
 * TELNET_EV_SUBNEGOTIATION
 
    Triggered whenever a TELNET sub-negotiation has been received.

--- a/libtelnet.c
+++ b/libtelnet.c
@@ -397,7 +397,7 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
 				_set_rfc1143(telnet, telopt, Q_US(q), Q_YES);
 				_send_negotiate(telnet, TELNET_DO, telopt);
 				NEGOTIATE_EVENT(telnet, TELNET_EV_WILL, telopt);
-				NEGOTIATE_EVENT(telnet, TELNET_EV_ENABLE_HIM, telopt);
+                NEGOTIATE_EVENT(telnet, TELNET_EV_ENABLE_HIM, telopt);
 			} else
 				_send_negotiate(telnet, TELNET_DONT, telopt);
 			break;
@@ -416,7 +416,7 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
             /* we received a WILL after sending a DO. enable this remote option. */
 			_set_rfc1143(telnet, telopt, Q_US(q), Q_YES);
 			NEGOTIATE_EVENT(telnet, TELNET_EV_WILL, telopt);
-			NEGOTIATE_EVENT(telnet, TELNET_EV_ENABLE_HIM, telopt);
+            NEGOTIATE_EVENT(telnet, TELNET_EV_ENABLE_HIM, telopt);
 			break;
 		case Q_WANTYES_OP:
 			_set_rfc1143(telnet, telopt, Q_US(q), Q_WANTNO);
@@ -433,7 +433,7 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
 			_set_rfc1143(telnet, telopt, Q_US(q), Q_NO);
 			_send_negotiate(telnet, TELNET_DONT, telopt);
 			NEGOTIATE_EVENT(telnet, TELNET_EV_WONT, telopt);
-			NEGOTIATE_EVENT(telnet, TELNET_EV_DISABLE_HIM, telopt);
+            NEGOTIATE_EVENT(telnet, TELNET_EV_DISABLE_HIM, telopt);
 			break;
 		case Q_WANTNO:
 			_set_rfc1143(telnet, telopt, Q_US(q), Q_NO);

--- a/libtelnet.c
+++ b/libtelnet.c
@@ -393,9 +393,11 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
 		switch (Q_HIM(q)) {
 		case Q_NO:
 			if (_check_telopt(telnet, telopt, 0)) {
+			    /* we received a WILL without having first sent a DO, but support this remote option. */
 				_set_rfc1143(telnet, telopt, Q_US(q), Q_YES);
 				_send_negotiate(telnet, TELNET_DO, telopt);
 				NEGOTIATE_EVENT(telnet, TELNET_EV_WILL, telopt);
+				NEGOTIATE_EVENT(telnet, TELNET_EV_ENABLE_HIM, telopt);
 			} else
 				_send_negotiate(telnet, TELNET_DONT, telopt);
 			break;
@@ -411,8 +413,10 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
 					"DONT answered by WILL");
 			break;
 		case Q_WANTYES:
+            /* we received a WILL after sending a DO. enable this remote option. */
 			_set_rfc1143(telnet, telopt, Q_US(q), Q_YES);
 			NEGOTIATE_EVENT(telnet, TELNET_EV_WILL, telopt);
+			NEGOTIATE_EVENT(telnet, TELNET_EV_ENABLE_HIM, telopt);
 			break;
 		case Q_WANTYES_OP:
 			_set_rfc1143(telnet, telopt, Q_US(q), Q_WANTNO);
@@ -429,6 +433,7 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
 			_set_rfc1143(telnet, telopt, Q_US(q), Q_NO);
 			_send_negotiate(telnet, TELNET_DONT, telopt);
 			NEGOTIATE_EVENT(telnet, TELNET_EV_WONT, telopt);
+			NEGOTIATE_EVENT(telnet, TELNET_EV_DISABLE_HIM, telopt);
 			break;
 		case Q_WANTNO:
 			_set_rfc1143(telnet, telopt, Q_US(q), Q_NO);
@@ -454,6 +459,7 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
 				_set_rfc1143(telnet, telopt, Q_YES, Q_HIM(q));
 				_send_negotiate(telnet, TELNET_WILL, telopt);
 				NEGOTIATE_EVENT(telnet, TELNET_EV_DO, telopt);
+                NEGOTIATE_EVENT(telnet, TELNET_EV_ENABLE_US, telopt);
 			} else
 				_send_negotiate(telnet, TELNET_WONT, telopt);
 			break;
@@ -471,6 +477,7 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
 		case Q_WANTYES:
 			_set_rfc1143(telnet, telopt, Q_YES, Q_HIM(q));
 			NEGOTIATE_EVENT(telnet, TELNET_EV_DO, telopt);
+			NEGOTIATE_EVENT(telnet, TELNET_EV_ENABLE_US, telopt);
 			break;
 		case Q_WANTYES_OP:
 			_set_rfc1143(telnet, telopt, Q_WANTNO, Q_HIM(q));
@@ -487,6 +494,7 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
 			_set_rfc1143(telnet, telopt, Q_NO, Q_HIM(q));
 			_send_negotiate(telnet, TELNET_WONT, telopt);
 			NEGOTIATE_EVENT(telnet, TELNET_EV_DONT, telopt);
+			NEGOTIATE_EVENT(telnet, TELNET_EV_DISABLE_US, telopt);
 			break;
 		case Q_WANTNO:
 			_set_rfc1143(telnet, telopt, Q_NO, Q_HIM(q));

--- a/libtelnet.h
+++ b/libtelnet.h
@@ -212,6 +212,10 @@ enum telnet_event_type_t {
 	TELNET_EV_DO,              /*!< DO option negotiation received */
 	TELNET_EV_DONT,            /*!< DONT option negotiation received */
 	TELNET_EV_SUBNEGOTIATION,  /*!< sub-negotiation data received */
+	TELNET_EV_ENABLE_US,       /*!< telopt enabled for us */
+	TELNET_EV_ENABLE_HIM,      /*!< telopt enabled for him */
+	TELNET_EV_DISABLE_US,      /*!< telopt disabled for us */
+	TELNET_EV_DISABLE_HIM,     /*!< telopt disabled for him */
 	TELNET_EV_COMPRESS,        /*!< compression has been enabled */
 	TELNET_EV_ZMP,             /*!< ZMP command has been received */
 	TELNET_EV_TTYPE,           /*!< TTYPE command has been received */


### PR DESCRIPTION
This pull request aims to solve what I view is an issue with the current library - the application has no idea when the telopt status changed! It has to maintain a separate tracker for when WILL / DO / DONT/ WONT was sent... and has no way to check the telnet_t's internal state when it receives a TELNET_EV_WILL, etc.

By adding in new events, now the application can know how to react.

I decided to create this after realizing that there was no simple way to know when the server has enabled MCCP2 so that it can know when to send an IAC SB MCCP2 IAC SE.

If I have overlooked something major please let me know.