### PR TITLE
Resolve Redefinition Issue

### DIFF
--- a/libtelnet.c
+++ b/libtelnet.c
@@ -15,7 +15,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#include <string.h>
 #include <stdarg.h>
 
 /* Win32 compatibility */


### PR DESCRIPTION
The 'string.h' header was included twice in 'libtelnet.c', causing redeclaration errors.